### PR TITLE
It seems that co-event-wrap module is not used?

### DIFF
--- a/lib/socket.io/socket.js
+++ b/lib/socket.io/socket.js
@@ -13,7 +13,6 @@
 var debug = require('debug')('koa.io:socket.io:socket');
 var OriginalSocket = require('socket.io/lib/socket');
 var delegate = require('delegates');
-var wrap = require('co-event-wrap');
 var Cookies = require('cookies');
 var parse = require('parseurl');
 var qs = require('querystring');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "dependencies": {
     "co": "~3.1.0",
-    "co-event-wrap": "~0.1.0",
     "cookies": "~0.5.0",
     "debug": "~2.1.0",
     "delegates": "~0.1.0",


### PR DESCRIPTION
So can we remove it as dependency?