### PR TITLE
upgrade dependencies

### DIFF
--- a/lib/socket.io/namespace.js
+++ b/lib/socket.io/namespace.js
@@ -38,7 +38,7 @@ exports.add = function (client, fn) {
 
   var self = this;
 
-  co(this.gen).call(socket, function (err) {
+  co.wrap(this.gen).call(socket, function (err) {
     if (client.conn.readyState === 'open') {
       if (err) {
         return socket.socket.error(err.data || err.message);

--- a/lib/socket.io/router.js
+++ b/lib/socket.io/router.js
@@ -60,7 +60,7 @@ Router.prototype.middleware = function () {
       context.event = args[0];
       context.data = args.slice(1);
 
-      co(gen).call(context, function (err) {
+      co.wrap(gen).call(context, function (err) {
         if (err) console.error(err.stack);
         //TODO: error
         socket._onevent(packet);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "co": "~3.1.0",
+    "co": "~4.4.0",
     "cookies": "~0.5.0",
     "debug": "~2.1.1",
     "delegates": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -26,24 +26,24 @@
   "dependencies": {
     "co": "~3.1.0",
     "cookies": "~0.5.0",
-    "debug": "~2.1.0",
+    "debug": "~2.1.1",
     "delegates": "~0.1.0",
-    "koa": "~0.13.0",
+    "koa": "~0.18.0",
     "koa-compose": "~2.3.0",
-    "koa-generic-session": "~1.2.2",
+    "koa-generic-session": "~1.6.0",
     "parseurl": "~1.3.0",
-    "socket.io": "~1.2.0"
+    "socket.io": "~1.3.4"
   },
   "devDependencies": {
     "autod": "1",
-    "istanbul-harmony": "~0.3.0",
+    "istanbul-harmony": "~0.3.1",
     "koa-static": "~1.4.7",
-    "koa-static-cache": "~1.2.0",
-    "mocha": "~2.0.1",
+    "koa-static-cache": "~3.0.1",
+    "mocha": "~2.1.0",
     "pedding": "~1.0.0",
-    "should": "~4.1.0",
-    "socket.io-client": "~1.2.0",
-    "supertest": "~0.14.0"
+    "should": "~5.0.0",
+    "socket.io-client": "~1.3.4",
+    "supertest": "~0.15.0"
   },
   "engine": {
     "node": ">=0.10"


### PR DESCRIPTION
Breaking change from co v4. Added co.wrap() as per [https://github.com/tj/co#co-v4](https://github.com/tj/co#co-v4) and the tests seem to pass.