### PR TITLE
fix multiple namespaces having the same router and calling the routes multiple times

### DIFF
--- a/lib/socket.io/index.js
+++ b/lib/socket.io/index.js
@@ -13,7 +13,6 @@
 var Namespace = require('socket.io/lib/namespace');
 var ExtentNamespace = require('./namespace');
 
-Namespace.prototype.router = ExtentNamespace.router;
 Namespace.prototype.route = ExtentNamespace.route;
 Namespace.prototype.add = ExtentNamespace.add;
 Namespace.prototype.use = ExtentNamespace.use;

--- a/lib/socket.io/index.js
+++ b/lib/socket.io/index.js
@@ -12,7 +12,12 @@
 
 var Namespace = require('socket.io/lib/namespace');
 var ExtentNamespace = require('./namespace');
+var Router = require('./router');
 
+Namespace.prototype.__defineGetter__('router', function () {
+	if(!this._router) this._router = Router();
+  return this._router;
+});
 Namespace.prototype.route = ExtentNamespace.route;
 Namespace.prototype.add = ExtentNamespace.add;
 Namespace.prototype.use = ExtentNamespace.use;

--- a/lib/socket.io/namespace.js
+++ b/lib/socket.io/namespace.js
@@ -26,6 +26,7 @@ var co = require('co');
 
 exports.add = function (client, fn) {
   debug('adding socket to nsp %s', this.name);
+  if(!this.router) this.router = Router();
   var socket = Socket(this, client);
   socket._fn = fn;
 
@@ -73,12 +74,6 @@ exports.route = function (event, handler) {
   this.router.route(event, handler);
   return this;
 };
-
-/**
- * init the router
- */
-
-exports.router = Router();
 
 /**
  * onconnect middleware

--- a/lib/socket.io/namespace.js
+++ b/lib/socket.io/namespace.js
@@ -13,7 +13,6 @@
 var debug = require('debug')('koa.io:socket.io:namespace');
 var compose = require('koa-compose');
 var Socket = require('./socket');
-var Router = require('./router');
 var co = require('co');
 
 /**
@@ -26,7 +25,6 @@ var co = require('co');
 
 exports.add = function (client, fn) {
   debug('adding socket to nsp %s', this.name);
-  if(!this.router) this.router = Router();
   var socket = Socket(this, client);
   socket._fn = fn;
 
@@ -71,7 +69,6 @@ exports.use = function (fn) {
  */
 
 exports.route = function (event, handler) {
-  if(!this.router) this.router = Router();
   this.router.route(event, handler);
   return this;
 };

--- a/lib/socket.io/namespace.js
+++ b/lib/socket.io/namespace.js
@@ -71,6 +71,7 @@ exports.use = function (fn) {
  */
 
 exports.route = function (event, handler) {
+  if(!this.router) this.router = Router();
   this.router.route(event, handler);
   return this;
 };

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -63,6 +63,27 @@ describe('lib/application.js', function () {
           });
         });
       });
+
+      it('should echo message', function (done) {
+        var app = App();
+        var server = app.listen();
+
+        request(server)
+          .get('/')
+          .expect(200)
+          .expect('hello', function (err, res) {
+          should.not.exist(err);
+          var cookie = encodeURIComponent(res.headers['set-cookie'].join(';'));
+          var socket = client(server, {query: 'cookie=' + cookie});
+          done = pedding(done, 2);
+          socket.on('connect', done);
+          socket.on('message', function (message) {
+            message.should.equal('message');
+            done();
+          });
+          socket.emit('message', 'message');
+        });
+      });
     });
   });
 

--- a/test/supports/app.js
+++ b/test/supports/app.js
@@ -42,6 +42,9 @@ module.exports = function SessionApp() {
 
   app.io.route('message', function (next, message) {
     this.broadcase.emit('message', message);
+  app.io.route('message', function* (next, message) {
+    this.emit('message', message);
+    yield *next;
   });
 
   return app;

--- a/test/supports/app.js
+++ b/test/supports/app.js
@@ -40,8 +40,6 @@ module.exports = function SessionApp() {
     this.emit('user leave', this.session.user.name);
   });
 
-  app.io.route('message', function (next, message) {
-    this.broadcase.emit('message', message);
   app.io.route('message', function* (next, message) {
     this.emit('message', message);
     yield *next;


### PR DESCRIPTION
If you have multiple namespaces or multiple instances of socket.io (like in the tests), you get multiple calls on a route for one socket call, because the router gets initialized once, globally.

With this fix, the router now gets initialized once per namespace object by checking if a router property already exists. The only way to change the constructor/function of socket.io/lib/namespace that came to my mind are doing dark things with the require cache, and I did not want to go there.

Added a test for the echo route.