### PR TITLE
ack FIX added to arguments and context

### DIFF
--- a/lib/socket.io/router.js
+++ b/lib/socket.io/router.js
@@ -94,6 +94,12 @@ Router.prototype.middleware = function middleware() {
         debug('event args not exist');
         return socket._onevent(packet);
       }
+      
+      if (null != packet.id) {
+        debug('attaching ack callback to event');
+        self.ack = this.ack(packet.id);
+        args.push(self.ack);
+      }
 
       self.event = args[0];
       self.data = args.slice(1);


### PR DESCRIPTION
Please merge this pull request for fixing unability to use acknolagements.
Example usage
```
this.ack(someData);
```
or
```
function *(next, ack) {
  ack(someData);
}
```